### PR TITLE
CIR-2031 revert collection document field name and index

### DIFF
--- a/app/uk/gov/hmrc/bankaccountreputationthirdpartycache/cache/CacheRepository.scala
+++ b/app/uk/gov/hmrc/bankaccountreputationthirdpartycache/cache/CacheRepository.scala
@@ -25,7 +25,8 @@ import uk.gov.hmrc.bankaccountreputationthirdpartycache.config.AppConfig
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 
-import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.time.{Clock, Instant}
 import java.util.concurrent.TimeUnit
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
@@ -38,7 +39,7 @@ abstract class CacheRepository @Inject()(
                                         )(implicit ec: ExecutionContext, appConfig: AppConfig)
   extends PlayMongoRepository[EncryptedCacheEntry](component, collectionName, EncryptedCacheEntry.cacheFormat, Seq(
     IndexModel(ascending("key"), IndexOptions().name("uniqueKeyIndex").unique(true)),
-    IndexModel(ascending("lastUpdated"), IndexOptions().name("lastUpdatedIdx").expireAfter(expiryDays, TimeUnit.DAYS))
+    IndexModel(ascending("expiryDate"), IndexOptions().name("expiryDateIndex").expireAfter(0, TimeUnit.DAYS)),
   ), replaceIndexes = appConfig.cacheReplaceIndexes()) {
 
   def findByRequest(encryptedKey: String)(implicit ec: ExecutionContext): Future[Option[String]] = {
@@ -57,7 +58,7 @@ abstract class CacheRepository @Inject()(
       EncryptedCacheEntry(
         encryptedKey,
         encryptedData,
-        Instant.now()
+        Instant.now(Clock.systemUTC()).plus(expiryDays, ChronoUnit.DAYS)
       ),
       ReplaceOptions().upsert(true)
     ).toFuture()

--- a/app/uk/gov/hmrc/bankaccountreputationthirdpartycache/cache/EncryptedCacheEntry.scala
+++ b/app/uk/gov/hmrc/bankaccountreputationthirdpartycache/cache/EncryptedCacheEntry.scala
@@ -23,7 +23,7 @@ import java.time.Instant
 
 case class EncryptedCacheEntry(key: String,
                                data: String,
-                               lastUpdated: Instant)
+                               expiryDate: Instant)
 
 object EncryptedCacheEntry {
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -84,7 +84,7 @@ mongodb {
   payee.personal.cacheItemExpiryDays = 40
   payee.business.cacheItemExpiryDays = 120
 
-  replaceIndexes = false
+  replaceIndexes = true
 }
 
 basicAuth {


### PR DESCRIPTION
Revert the document field name change, increment the expiry date on document insert by adding the additional TTL days to the `expiryDate` field and set the mongo index TTL to zero days. This will expire the document on the day set in the documents records `expiryDate` field.